### PR TITLE
Add assignees to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":semanticCommits"],
+  "assignees": ["malleroid"],
   "labels": ["dependencies"],
   "timezone": "Asia/Tokyo",
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Overview 🎯

Automatically assign PRs created by Renovate to the repository owner

## Changes ✏️

- Add `assignees` field to `renovate.json` (`malleroid`)

## How to Test 🧪

- Verify that the next PR created by Renovate has the assignee set

## Related 🔗

N/A

## Notes 🗒️

N/A