### PR TITLE
Add DuckDB container config

### DIFF
--- a/docker/duckdb/Dockerfile
+++ b/docker/duckdb/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DUCKDB_VERSION=1.3.2
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        gzip \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -q https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.gz -O /tmp/duckdb_cli-linux-amd64.gz \
+    && gunzip /tmp/duckdb_cli-linux-amd64.gz \
+    && install /tmp/duckdb_cli-linux-amd64 /usr/local/bin/duckdb \
+    && rm /tmp/duckdb_cli-linux-amd64
+
+WORKDIR /judge


### PR DESCRIPTION
## Overview 🎯

Add Dockerfile for the AtCoder DuckDB (1.3.2) judge environment

## Changes ✏️

- Add `docker/duckdb/Dockerfile` with DuckDB CLI 1.3.2 installed from GitHub Releases
- Base image: `ubuntu:24.04`, working directory: `/judge`

## How to Test 🧪

- Run `docker build docker/duckdb/` and verify the image builds successfully
- Run `duckdb --version` inside the container to confirm version 1.3.2 (requires x86_64 host or emulation)

## Related 🔗

N/A

## Notes 🗒️

- DuckDB CLI is a single static binary — no additional dependencies required
- Judge execution command: `duckdb -noheader -f Main.sql`