### PR TITLE
Add Go (1.25.1) judge environment Dockerfile

### DIFF
--- a/docker/go/Dockerfile
+++ b/docker/go/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  wget \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG GO_VERSION=1.25.1
+
+RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz -O /tmp/go.tar.gz \
+  && tar -C /opt -xf /tmp/go.tar.gz \
+  && rm /tmp/go.tar.gz
+
+ENV PATH=$PATH:/opt/go/bin \
+  GOPATH=/home/runner/go
+
+WORKDIR /judge
+
+RUN go mod init atcoder.jp/golang \
+  && go get \
+    github.com/emirpasic/gods \
+    gonum.org/v1/gonum \
+    github.com/liyue201/gostl \
+    github.com/benbjohnson/immutable \
+    golang.org/x/exp \
+    github.com/monkukui/ac-library-go


### PR DESCRIPTION
## Overview 🎯

Add Dockerfile for the Go (go 1.25.1) AtCoder judge environment

## Changes ✏️

- Add `docker/go/Dockerfile` with:
  - Base image: `ubuntu:24.04`
  - Go 1.25.1 official binary installed to `/opt/go`
  - 6 external libraries pre-installed via `go get` (gods, gonum, gostl, immutable, golang.org/x/exp, ac-library-go)
  - Working directory: `/judge`

## How to Test 🧪

- Build the image on an amd64 machine:
  ```
  docker build -t atcoder-go docker/go/
  ```
- Verify Go is installed: `docker run --rm atcoder-go go version`
- Verify libraries are available: `docker run --rm atcoder-go cat go.sum`

## Related 🔗

N/A

## Notes 🗒️

- The Dockerfile targets `linux/amd64` as per the AtCoder judge environment spec
- Go binary is downloaded from the official Go distribution site